### PR TITLE
Fix: Audio preview got replayed upon changing Queue pagination

### DIFF
--- a/resources/js/Components/Beatmap.jsx
+++ b/resources/js/Components/Beatmap.jsx
@@ -1,6 +1,6 @@
 import { Link } from "@inertiajs/react";
 import { BeatmapStatus } from "@/Components/BeatmapStatus.jsx";
-import { useEffect, useState, useRef } from "react";
+import { useState } from "react";
 import { usePreview } from "@/Util/stores";
 import { Button } from "@/Components/ui/button";
 import { Play, Pause } from "lucide-react";
@@ -90,22 +90,11 @@ export const Beatmap = (props) => {
 };
 
 export const Beatmaps = (props) => {
-    const { preview } = usePreview((state) => state);
-    const audioRef = useRef(null);
-
-    useEffect(() => {
-        if (preview !== "") {
-            audioRef.current.volume = 0.3;
-            audioRef.current.play();
-        }
-    }, [preview]);
-
     return (
         <>
             {props.beatmaps.data.map((beatmap) => (
                 <Beatmap key={beatmap.id} beatmap={beatmap} auth={props.auth} />
             ))}
-            <audio ref={audioRef} src={preview} />
         </>
     );
 };

--- a/resources/js/Pages/Queue.jsx
+++ b/resources/js/Pages/Queue.jsx
@@ -2,8 +2,13 @@ import { Head, Link, useForm } from "@inertiajs/react";
 import App from "@/Layouts/App.jsx";
 import LoginRequired from "@/Components/LoginRequired.jsx";
 import { Beatmap, Beatmaps } from "@/Components/Beatmap.jsx";
+import { usePreview } from "@/Util/stores";
+import { useEffect, useRef } from "react";
 
 const Queue = ({ auth, beatmaps, title }) => {
+    const { preview, updatePreview } = usePreview();
+    const audioRef = useRef(null);
+
     let params = new URLSearchParams(window.location.search);
     let query_url = window.location.pathname;
 
@@ -20,6 +25,13 @@ const Queue = ({ auth, beatmaps, title }) => {
             preserveState: true,
         });
     };
+
+    useEffect(() => {
+        if (preview !== "") {
+            audioRef.current.volume = 0.3;
+            audioRef.current.play();
+        }
+    }, [preview]);
 
     return (
         <>
@@ -133,6 +145,10 @@ const Queue = ({ auth, beatmaps, title }) => {
                             ))}
                         </ul>
                     </nav>
+
+                    <audio ref={audioRef} src={preview} onEnded={() => {
+                        updatePreview("")
+                    }}/>
                 </>
             )}
         </>


### PR DESCRIPTION
This would provide a fix to the audio preview of the page. At the current state, the audio preview will be replayed when users change the pagination in Queue page. This is happening because of the re-rendering of the `<Beatmaps/>` component which will trigger the `<audio/>` tag to play the preview again.
Since I cannot setup the development environment, nothing has been tested. Should there be any problem, please let me know.